### PR TITLE
[TiltEstimator.h] enable to compile on macOS

### DIFF
--- a/include/hrpsys-state-observation/TiltEstimator.h
+++ b/include/hrpsys-state-observation/TiltEstimator.h
@@ -11,6 +11,7 @@
 #define TiltEstimator_H
 
 #include <rtm/CorbaNaming.h>
+#include <rtm/idl/ExtendedDataTypes.hh>
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>


### PR DESCRIPTION
This PR enables to compile TiltEstimator on macOS.
I don't know why exactly but I had to include header files in which data types are defined before including *Port.h.
